### PR TITLE
Add sphinxcontrib-globalsubs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,9 @@ cornice.ext.sphinxext_
 sphinxcontrib-programoutput_
    Sphinx extension to include program output into documents.
 
+sphinxcontrib-globalsubs_
+   Adds support for global reStructuredText substitutions via a dictionary, as an alternative to putting them in `rst_prolog` or `rst_epilog`.
+
 sphinxcontrib-napoleon_
    Napoleon is a pre-processor that parses NumPy and Google style docstrings.
 
@@ -185,6 +188,7 @@ sphinx-gitstamp_
 .. _sphinxcontrib-constdata: https://documatt.gitlab.io/sphinxcontrib-constdata/
 .. _sphinxcontrib-docbookrestapi: https://github.com/stackforge/sphinxcontrib-docbookrestapi
 .. _sphinxcontrib-fulltoc: https://github.com/dreamhost/sphinxcontrib-fulltoc
+.. _sphinxcontrib-globalsubs: https://github.com/missinglinkelectronics/sphinxcontrib-globalsubs
 .. _sphinxcontrib-httpdomain: https://pythonhosted.org/sphinxcontrib-httpdomain/
 .. _cornice.ext.sphinxext: https://cornice.readthedocs.io/en/latest/sphinx.html
 .. _sphinxcontrib-programoutput: https://github.com/NextThought/sphinxcontrib-programoutput


### PR DESCRIPTION
The [sphinxcontrib-globalsubs](https://github.com/missinglinkelectronics/sphinxcontrib-globalsubs) extension is awesome because using it let us speed up our Sphinx build by a factor of two!

For a bit of background, the Sphinx documentation states that you can add global substitutions via the `rst_prolog` or `rst_epilog` configuration variables (which contain text that will be prepended or appended to every reStructuredText source file).  However, we didn't realize that adding ∼200 substitutions in `rst_epilog` would significantly slow down our documentation builds.  

After finding https://github.com/sphinx-doc/sphinx/issues/2173, I learned about `sphinxcontrib-globalsubs`.  After defining the substitutions with this extension instead of `rst_epilog`, I found that our documentation build dropped from ∼415 s to ∼200 s!  